### PR TITLE
Update DDEV install instructions for pkg.ddev.com

### DIFF
--- a/src/components/quickstart/Cloud.astro
+++ b/src/components/quickstart/Cloud.astro
@@ -26,7 +26,7 @@ const { latestVersion } = Astro.props
           > using Gitpod and install DDEV:
         </p>
         <Terminal
-          code={`→ curl -fsSL https://apt.fury.io/ddev/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n→ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/ddev/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n→ sudo apt update && sudo apt install -y ddev
+          code={`→ curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n→ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n→ sudo apt update && sudo apt install -y ddev
 `}
         />
       </div>

--- a/src/components/quickstart/Linux.astro
+++ b/src/components/quickstart/Linux.astro
@@ -96,7 +96,7 @@ const { latestVersion } = Astro.props
       <div class="prose py-5">
         <Terminal
           type="ubuntu"
-          code={`$ curl -fsSL https://apt.fury.io/ddev/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/ddev/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n$ sudo apt update && sudo apt install -y ddev
+          code={`$ curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n$ sudo apt update && sudo apt install -y ddev
 `}
         />
       </div>
@@ -105,7 +105,7 @@ const { latestVersion } = Astro.props
       <div class="prose py-5">
         <Terminal
           type="ubuntu"
-          code={`$ echo '[ddev]\nname=DDEV Repo\nbaseurl=https://yum.fury.io/ddev/\nenabled=1\ngpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo\n$ sudo dnf install --refresh ddev`}
+          code={`$ echo '[ddev]\nname=DDEV Repo\nbaseurl=https://pkg.ddev.com/yum/\nenabled=1\ngpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo\n$ sudo dnf install --refresh ddev`}
         />
       </div>
     </Fragment>
@@ -113,7 +113,7 @@ const { latestVersion } = Astro.props
       <div class="prose py-5">
         <Terminal
           type="ubuntu"
-          code={`$ curl -fsSL https://apt.fury.io/ddev/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://apt.fury.io/ddev/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n$ sudo apt update && sudo apt install -y ddev
+          code={`$ curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ddev.gpg > /dev/null\n$ echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list\n$ sudo apt update && sudo apt install -y ddev
 `}
         />
       </div>
@@ -122,7 +122,7 @@ const { latestVersion } = Astro.props
       <div class="prose py-5">
         <Terminal
           type="ubuntu"
-          code={`$ echo '[ddev]\nname=DDEV Repo\nbaseurl=https://yum.fury.io/ddev/\nenabled=1\ngpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo\n$ sudo dnf install --refresh ddev`}
+          code={`$ echo '[ddev]\nname=DDEV Repo\nbaseurl=https://pkg.ddev.com/yum/\nenabled=1\ngpgcheck=0' | sudo tee -a /etc/yum.repos.d/ddev.repo\n$ sudo dnf install --refresh ddev`}
         />
       </div>
     </Fragment>


### PR DESCRIPTION
* pkg.ddev.com is the new CNAME for packages; update it.
* Report of a typo in https://discord.com/channels/664580571770388500/1087760493986467871/1094750674031497256 - apparently happened during drud/ddev changeover.

This is related to the same set of changes for the docs:
* https://github.com/ddev/ddev/pull/4808