### PR TITLE
Add homepage architecture callout

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -1,0 +1,3 @@
+<div class="inline-block border rounded text-xs mx-[2px] px-1 py-0 relative bottom-px">
+  <slot />
+</div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,11 +2,13 @@
 /**
  * The large, leading copy and image used on the homepage.
  */
-import CtaButton from "../components/CtaButton.astro"
+import CtaButton from "@components/CtaButton.astro"
+import Icon from "@components/Icon.astro"
 import AnimatedTerminal from "./AnimatedTerminal.astro"
+import { CloudIcon } from "@heroicons/react/24/solid/index.js"
 ---
 
-<div class="mt-12 py-32 relative overflow-x-hidden">
+<div class="mt-12 pt-24 pb-32 relative overflow-x-hidden">
   <div class="z-10 max-w-4xl mx-auto relative">
     <div class="max-w-2xl px-6 lg:px-0">
       <h1 class="text-5xl font-bold">
@@ -28,6 +30,51 @@ import AnimatedTerminal from "./AnimatedTerminal.astro"
           target="_blank"
         />
       </div>
+    </div>
+
+    <div class="mt-8 text-slate-500">
+      <ul class="flex space-x-7">
+        <li>
+          <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
+            ><Icon name="Apple" />
+          </span>
+          macOS <div
+            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
+          >
+            Apple
+          </div>
+          <div
+            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
+          >
+            Intel
+          </div>
+        </li>
+        <li>
+          <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
+            ><Icon name="Windows" />
+          </span>Windows
+        </li>
+        <li>
+          <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
+            ><Icon name="Linux" />
+          </span>Linux
+        </li>
+        <li>
+          <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
+            ><CloudIcon />
+          </span>Cloud
+          <div
+            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
+          >
+            Codespaces
+          </div>
+          <div
+            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
+          >
+            Gitpod
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -32,9 +32,9 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
       </div>
     </div>
 
-    <div class="mt-8 text-slate-500">
-      <ul class="flex space-x-7">
-        <li>
+    <div class="mt-4 text-slate-500 max-w-2xl px-6 lg:px-0">
+      <ul class="flex flex-wrap space-x-7 justify-center md:justify-start">
+        <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><Icon name="Apple" />
           </span>
@@ -49,17 +49,17 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
             Intel
           </div>
         </li>
-        <li>
+        <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><Icon name="Windows" />
           </span>Windows
         </li>
-        <li>
+        <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><Icon name="Linux" />
           </span>Linux
         </li>
-        <li>
+        <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><CloudIcon />
           </span>Cloud

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,6 +2,7 @@
 /**
  * The large, leading copy and image used on the homepage.
  */
+import Badge from "@components/Badge.astro"
 import CtaButton from "@components/CtaButton.astro"
 import Icon from "@components/Icon.astro"
 import AnimatedTerminal from "./AnimatedTerminal.astro"
@@ -38,16 +39,7 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><Icon name="Apple" />
           </span>
-          macOS <div
-            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
-          >
-            Apple
-          </div>
-          <div
-            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
-          >
-            Intel
-          </div>
+          macOS <Badge>M1</Badge><Badge>M2</Badge><Badge>Intel</Badge>
         </li>
         <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
@@ -63,16 +55,7 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><CloudIcon />
           </span>Cloud
-          <div
-            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
-          >
-            Codespaces
-          </div>
-          <div
-            class="inline-block border rounded text-xs px-1 py-0 relative bottom-px"
-          >
-            Gitpod
-          </div>
+          <Badge>Codespaces</Badge><Badge>Gitpod</Badge>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## The Issue

Mayank pointed out [in Discord](https://discord.com/channels/664580571770388500/1096577998712487936/1096577998712487936) that one of DDEV’s strengths is its platform support, which includes macOS M1 and M2 architecture. We don’t point that out anywhere on the homepage despite it being important!

## How This PR Solves The Issue

This adds a prominent architecture callout to the homepage, using “Intel” and “Apple” next to “macOS” to specifically identify those platforms. (This seemed like it’d be more maintainable than listing out M1, M2, and continuing to tack on M* labels as new chips are released.)

<img width="922" alt="Screen Shot 2023-04-17 at 09 25 17 AM@2x" src="https://user-images.githubusercontent.com/2488775/232549848-9e1639e1-697e-4dc8-9042-5ee92b4ffbd5.png">

## Manual Testing Instructions

[Visit the preview build](https://feature-homepage-architectur.ddev-com-front-end.pages.dev) and see what you think! My goal was to keep it from being too loud, but reinforce the supported architectures in a way that’s as legible and accessible as anything else on the page.
