### PR TITLE
Add Contributor Training page and supporting content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "glob": "^10.2.2",
         "image-size": "^1.0.2",
         "linkedom": "^0.14.21",
+        "luxon": "^3.3.0",
         "marked": "^4.2.5",
         "mdast-util-to-string": "^3.1.0",
         "nanoid": "^4.0.1",
@@ -45,6 +46,8 @@
         "tailwindcss": "^3.2.4"
       },
       "devDependencies": {
+        "@tailwindcss/forms": "^0.5.4",
+        "@types/luxon": "^3.3.1",
         "@types/marked": "^4.0.8",
         "dotenv": "^16.0.3",
         "textlint": "^13.0.5",
@@ -1852,6 +1855,18 @@
         "escalade": "^3.1.1"
       }
     },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.4.tgz",
+      "integrity": "sha512-YAm12D3R7/9Mh4jFbYSMnsd6jG++8KxogWgqs7hbdo/86aWjjlIEvL7+QYdVELmAI0InXTpZqFIg5e7aDVWI2Q==",
+      "dev": true,
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
@@ -2831,6 +2846,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+      "integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA==",
+      "dev": true
     },
     "node_modules/@types/marked": {
       "version": "4.3.1",
@@ -6084,6 +6105,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -7095,6 +7124,15 @@
       "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
       "dependencies": {
         "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "glob": "^10.2.2",
     "image-size": "^1.0.2",
     "linkedom": "^0.14.21",
+    "luxon": "^3.3.0",
     "marked": "^4.2.5",
     "mdast-util-to-string": "^3.1.0",
     "nanoid": "^4.0.1",
@@ -50,6 +51,8 @@
     "tailwindcss": "^3.2.4"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.4",
+    "@types/luxon": "^3.3.1",
     "@types/marked": "^4.0.8",
     "dotenv": "^16.0.3",
     "textlint": "^13.0.5",

--- a/src/components/TrainingSignup.astro
+++ b/src/components/TrainingSignup.astro
@@ -1,0 +1,89 @@
+---
+---
+
+<div class="shadow-xl rounded-lg px-6 py-7">
+  <p class="mt-0 pt-0">
+    Sign up to get a Zoom invitation for your desired session.
+  </p>
+  <form action="https://crm.zoho.com/crm/WebToLeadForm">
+    <input
+      type="hidden"
+      name="xnQsjsdp"
+      value="e888d842d2182432c1bf117aecd6280f1bf0b73e665551779217573985104582"
+    />
+    <input type="hidden" name="zc_gad" id="zc_gad" value="" />
+    <input
+      type="hidden"
+      name="xmIwtLD"
+      value="d761f49b3421baca337046aa6e88b3577b9bde1a72416d4efa9653571fde49fa"
+    />
+    <input type="hidden" name="actionType" value="TGVhZHM=" />
+    <input type="hidden" name="returnURL" value="https://ddev.com/training" />
+
+    <div>
+      <div class="mb-4">
+        <label for="session" class="block text-xs font-medium text-gray-700">
+          Session
+        </label>
+
+        <input
+          type="text"
+          id="session"
+          class="mt-1 w-full rounded-md border-gray-200 shadow-sm sm:text-sm"
+          required
+        />
+      </div>
+    </div>
+
+    <div class="flex space-x-4">
+      <div class="w-1/2">
+        <label for="name" class="block text-xs font-medium text-gray-700">
+          Name
+        </label>
+
+        <input
+          type="text"
+          id="name"
+          class="mt-1 w-full rounded-md border-gray-200 shadow-sm sm:text-sm"
+          required
+        />
+      </div>
+
+      <div class="w-1/2 relative">
+        <label for="email" class="block text-xs font-medium text-gray-700"
+          >Email</label
+        >
+
+        <input
+          type="email"
+          id="email"
+          class="mt-1 w-full rounded-md border-gray-200 shadow-sm sm:text-sm"
+          required
+        />
+
+        <span
+          class="pointer-events-none absolute inset-y-0 end-0 grid w-10 place-content-center text-gray-500"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            class="h-4 w-4 top-[9px] relative"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M5.404 14.596A6.5 6.5 0 1116.5 10a1.25 1.25 0 01-2.5 0 4 4 0 10-.571 2.06A2.75 2.75 0 0018 10a8 8 0 10-2.343 5.657.75.75 0 00-1.06-1.06 6.5 6.5 0 01-9.193 0zM10 7.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5z"
+              clip-rule="evenodd"></path>
+          </svg>
+        </span>
+      </div>
+      <div>
+        <button
+          class="mt-5 inline-block rounded border border-transparent bg-blue-650 px-10 py-2 text-sm text-white hover:bg-transparent hover:bg-blue-800 hover:border-blue-800 hover:text-blue-800 focus:outline-none focus:ring active:text-blue-800"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/src/components/TrainingTable.astro
+++ b/src/components/TrainingTable.astro
@@ -1,0 +1,88 @@
+---
+import type { CollectionEntry } from "astro:content"
+import { DateTime, Settings } from "luxon"
+import { VideoCameraIcon } from "@heroicons/react/24/outline/index.js"
+
+Settings.defaultZone = "utc"
+
+export interface Props {
+  sessions: CollectionEntry<"trainings">[]
+}
+
+const { sessions } = Astro.props
+---
+
+<div class="overflow-x-auto">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Topic</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        sessions.map(
+          ({
+            body,
+            data: { title, sessionStart, sessionMinutes, recordingUrl },
+          }) => {
+            // Session start time (UTC)
+            const dt = DateTime.fromISO(sessionStart)
+            // Session start time (U.S. Mountain)
+            const dtRandy = dt.setZone("America/Denver")
+            // Title text to reiterate date + time
+            const timeString = `${sessionMinutes} minutes on ${dtRandy.toLocaleString(
+              DateTime.DATE_MED_WITH_WEEKDAY
+            )} at ${dtRandy.toLocaleString(DateTime.TIME_WITH_SHORT_OFFSET)}`
+
+            // Description and date for generated timeanddate.com link
+            const urlDescription = encodeURI(
+              `DDEV Contributor Training: ${title}`
+            )
+            const urlDate = dtRandy.toFormat("kkkkLLdd'T'HH")
+
+            return (
+              <tr>
+                <td title={timeString}>
+                  <a
+                    href={`https://www.timeanddate.com/worldclock/fixedtime.html?msg=${urlDescription}&iso=${urlDate}&p1=75&ah=1`}
+                    target="_blank"
+                  >
+                    {dt.toFormat("kkkk-LL-dd")}
+                  </a>
+                </td>
+                <td>
+                  <b>{title}</b>
+                  {body && <div class="opacity-75">{body}</div>}
+                </td>
+                <td class="text-right">
+                  {dt.diffNow("days").as("days") > 0 && (
+                    <button
+                      data-session={`${title} on ${dt.toFormat("kkkk-LL-dd")}`}
+                      class="register inline-block font-medium leading-tight border-b-2 hover:border-gray-500 pb-0.5 mx-2"
+                    >
+                      Register
+                    </button>
+                  )}
+                  {recordingUrl && (
+                    <a
+                      href={recordingUrl}
+                      class="whitespace-nowrap no-underline border-b-2 hover:border-gray-500 pb-0.5 mx-2"
+                      target="_blank"
+                      title="View Recording"
+                    >
+                      Recording
+                      <VideoCameraIcon className="w-4 h-4 inline-block" />
+                    </a>
+                  )}
+                </td>
+              </tr>
+            )
+          }
+        )
+      }
+    </tbody>
+  </table>
+</div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,8 +1,15 @@
-import { z, defineCollection } from 'astro:content'
+import { z, defineCollection } from "astro:content"
 import fs2 from "fs"
 import glob from "glob"
 
-const allowedCategories = ['Announcements', 'Community', 'DevOps', 'Performance', 'Guides', 'Videos']
+const allowedCategories = [
+  "Announcements",
+  "Community",
+  "DevOps",
+  "Performance",
+  "Guides",
+  "Videos",
+]
 
 /**
  * Quick and dirty method that returns full names of all existing authors.
@@ -11,14 +18,13 @@ const allowedCategories = ['Announcements', 'Community', 'DevOps', 'Performance'
 const getAuthorNames = () => {
   const files = glob.sync(`./src/content/authors/*.md`)
   const authorNames = files.map((file) => {
-    const contents = fs2.readFileSync(file, "utf-8");
+    const contents = fs2.readFileSync(file, "utf-8")
     const result = contents.match(new RegExp("name: (.*)"))
-    return result[1];
+    return result[1]
   })
 
-  return authorNames;
+  return authorNames
 }
-
 
 /**
  * Below we’re defining schemas for our Content Collections so their
@@ -33,8 +39,8 @@ const authorCollection = defineCollection({
     name: z.string(),
     firstName: z.string(),
     avatarUrl: z.string().optional(),
-  })
-});
+  }),
+})
 
 const blogCollection = defineCollection({
   schema: z.object({
@@ -44,19 +50,31 @@ const blogCollection = defineCollection({
     modifiedDate: z.date().optional(),
     modifiedComment: z.string().optional(),
     author: z.enum(getAuthorNames()),
-    featureImage: z.object({
-      src: z.string(),
-      alt: z.nullable(z.string()),
-      caption: z.nullable(z.string()).optional(),
-      credit: z.nullable(z.string()).optional(),
-      shadow: z.boolean().optional(),
-      hide: z.boolean().optional(),
-    }).optional(),
+    featureImage: z
+      .object({
+        src: z.string(),
+        alt: z.nullable(z.string()),
+        caption: z.nullable(z.string()).optional(),
+        credit: z.nullable(z.string()).optional(),
+        shadow: z.boolean().optional(),
+        hide: z.boolean().optional(),
+      })
+      .optional(),
     categories: z.array(z.enum(allowedCategories)),
-  })
-});
+  }),
+})
+
+const trainingsCollection = defineCollection({
+  schema: z.object({
+    title: z.string(),
+    sessionStart: z.string().datetime(),
+    sessionMinutes: z.number(),
+    recordingUrl: z.string().url().nullable(),
+  }),
+})
 
 export const collections = {
-  'blog': blogCollection,
-  'authors': authorCollection
-};
+  blog: blogCollection,
+  authors: authorCollection,
+  trainings: trainingsCollection,
+}

--- a/src/content/trainings/2023-add-ons.md
+++ b/src/content/trainings/2023-add-ons.md
@@ -1,0 +1,6 @@
+---
+title: Creating, Maintaining, and Testing DDEV Add-Ons
+sessionStart: "2023-11-07T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-amplitude.md
+++ b/src/content/trainings/2023-amplitude.md
@@ -1,0 +1,6 @@
+---
+title: Measuring and Analyzing Contributor Data with Amplitude
+sessionStart: "2023-10-31T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-architecture.md
+++ b/src/content/trainings/2023-architecture.md
@@ -1,0 +1,6 @@
+---
+title: "DDEV Architecture: Go, Docker, and Linux, Oh My"
+sessionStart: "2023-09-12T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-automated-tests.md
+++ b/src/content/trainings/2023-automated-tests.md
@@ -1,0 +1,6 @@
+---
+title: Automated Tests and How to Improve Them
+sessionStart: "2023-09-26T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-ddev.com.md
+++ b/src/content/trainings/2023-ddev.com.md
@@ -1,0 +1,8 @@
+---
+title: Maintain and Improve ddev.com
+sessionStart: "2023-08-15T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---
+
+Everybody can fix or improve ddev.com.

--- a/src/content/trainings/2023-docker-image.md
+++ b/src/content/trainings/2023-docker-image.md
@@ -1,0 +1,6 @@
+---
+title: Building and Pushing an Improved Docker Image
+sessionStart: "2023-08-29T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-docs.md
+++ b/src/content/trainings/2023-docs.md
@@ -1,0 +1,6 @@
+---
+title: Maintaining and Improving the Docs
+sessionStart: "2023-07-18T14:00:00Z"
+sessionMinutes: 60
+recordingUrl: https://www.dropbox.com/scl/fi/2d5qryxzgwa5zat9xz056/20230718_contributor_traiing_docs.mp4?rlkey=senzp6l6j8zq52vd4y74uhqfy&dl=0
+---

--- a/src/content/trainings/2023-features-prerelases.md
+++ b/src/content/trainings/2023-features-prerelases.md
@@ -1,0 +1,6 @@
+---
+title: Testing DDEV Features and v1.22.0 Prereleases
+sessionStart: "2023-07-11T14:00:00Z"
+sessionMinutes: 60
+recordingUrl: https://www.dropbox.com/scl/fi/8epf3vqrp6f5rf7w7up7l/20230711_contributor_training_testing_release.mp4?rlkey=s8zd82uc7a33kke9ksiqsi1yb&dl=0
+---

--- a/src/content/trainings/2023-go.md
+++ b/src/content/trainings/2023-go.md
@@ -1,0 +1,6 @@
+---
+title: Setting up a Go Development Environment
+sessionStart: "2023-07-25T14:00:00Z"
+sessionMinutes: 60
+recordingUrl: https://www.dropbox.com/scl/fi/gka3bwm3pwpchryg50l0t/20230725_contributor_training_go_environment.mp4?rlkey=3hlhugszdxi4hm6rmwlw28r5f&dl=0
+---

--- a/src/content/trainings/2023-local-testing.md
+++ b/src/content/trainings/2023-local-testing.md
@@ -1,0 +1,6 @@
+---
+title: Running Automated Tests Locally
+sessionStart: "2023-08-08T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-marketing.md
+++ b/src/content/trainings/2023-marketing.md
@@ -1,0 +1,6 @@
+---
+title: Participating in Marketing
+sessionStart: "2023-09-05T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-support.md
+++ b/src/content/trainings/2023-support.md
@@ -1,0 +1,6 @@
+---
+title: Supporting Others in Discord, GitHub Issues, and Stack Overflow
+sessionStart: "2023-08-22T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/content/trainings/2023-testing-infrastructure.md
+++ b/src/content/trainings/2023-testing-infrastructure.md
@@ -1,0 +1,6 @@
+---
+title: Testing Infrastructure
+sessionStart: "2023-09-19T14:00:00Z"
+sessionMinutes: 60
+recordingUrl:
+---

--- a/src/pages/support-ddev.astro
+++ b/src/pages/support-ddev.astro
@@ -43,6 +43,10 @@ const title = `Support DDEV`
           > a GitHub Issue or Pull Request.
         </p>
 
+        <aside class="w-full rounded border-1 bg-blue-100/50 px-4 leading-tight font-mono text-sm">
+          <p class="py-4">💡 Check out <a href="/training">contributor training</a> for ideas and best practices.</p>
+        </aside>
+
         <Img
           src="/img/pr.png"
           alt="Screenshot of GitHub PR #217, where @beeradb added new version notifications"

--- a/src/pages/training.astro
+++ b/src/pages/training.astro
@@ -1,0 +1,80 @@
+---
+import { getCollection } from "astro:content"
+import Layout from "@layouts/Layout.astro"
+import Heading from "@components/Heading.astro"
+import TrainingSignup from "@components/TrainingSignup.astro"
+import TrainingTable from "@components/TrainingTable.astro"
+
+const title = `Contributor Training`
+
+const posts = await getCollection("trainings")
+const sessions = posts.sort((a, b) => {
+  return new Date(a.data.sessionStart) > new Date(b.data.sessionStart) ? -1 : 1
+})
+const upcoming = sessions
+  .filter((entry) => {
+    return new Date(entry.data.sessionStart) > new Date()
+  })
+  .reverse()
+const past = sessions.filter((entry) => {
+  return new Date(entry.data.sessionStart) <= new Date()
+})
+---
+
+<script>
+  const registrationFormSessionInput = document.getElementById("session")
+  const registerButtons = document.querySelectorAll("button.register")
+  Array.from(registerButtons).map((element) => {
+    element.addEventListener("click", (e) => {
+      registrationFormSessionInput?.setAttribute(
+        "value",
+        e.target.getAttribute("data-session")
+      )
+      location.hash = "#register"
+    })
+  })
+</script>
+
+<Layout
+  title={title}
+  description={`Upcoming and past training sessions for people interested in maintaining DDEV.`}
+>
+  <main class="max-w-4xl mx-auto mb-24">
+    <Heading title={title} />
+    <div class="prose px-6 lg:px-0 text-lg mt-0 mb-24">
+      <p>
+        Live training on contributing topics and themes, with recordings from
+        past events.
+      </p>
+    </div>
+    <div class="lg:flex">
+      <div class="px-6 lg:px-0 w-full max-w-3xl">
+        <div class="prose">
+          <h2>Upcoming Sessions</h2>
+
+          <p>
+            Live training sessions are held weekly on Tuesdays at 8am US MT /
+            5pm CET or CEST.
+          </p>
+        </div>
+        <div class="prose max-w-none">
+          <TrainingTable sessions={upcoming} />
+        </div>
+
+        <div id="register" class="prose mb-4 mt-24">
+          <h2>Register</h2>
+        </div>
+        <div class="prose max-w-none mb-32">
+          <TrainingSignup />
+        </div>
+
+        <div class="prose">
+          <h2>Past Sessions</h2>
+        </div>
+        <div class="prose max-w-none">
+          <TrainingTable sessions={past} />
+        </div>
+      </div>
+    </div>
+  </main>
+</Layout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -45,5 +45,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],
 }


### PR DESCRIPTION
## The Issue

The attempt to add a signup form with inline CSS, JavaScript, and markup within Markdown content isn’t going very well in #72. Using a dated blog post as a persistent source of information also stretches the purpose of dated posts that should probably be reserved for topical adventures and announcements.

The timeanddate.com links are also helpful but cumbersome to manage.

## How This PR Solves The Issue

> 👀 Build preview: https://feature-training-section.ddev-com-front-end.pages.dev/training/

Since contributor training would probably be an ongoing thing, this creates a dedicated page and content type for it.

This means each session is represented by a little `.md` file in `src/content/trainings/`:

```md
---
title: Testing Infrastructure
sessionStart: "2023-09-19T14:00:00Z"
sessionMinutes: 60
recordingUrl:
---
```

This information is all that’s necessary to generate the page you’ll see in the build preview. `sessionStart` is in UTC, the mother of all timezones, and `sessionMinutes` is included because currently there’s no indication up front how long these sessions are supposed to be. `recordingUrl` requires a valid URL and can be added later.

Each field gets validated, and I rewrote titles to maintain Title Case and try to be succinct—with one exception that demonstrates how content is presented when you add it to the Markdown file. (Which should probably be used sparingly.)

### Not-Obvious Features

#### timeanddate.com links are generated automatically and include the full session title. 

![Screen Shot 2023-07-26 at 07 36 30 PM@2x](https://github.com/ddev/ddev.com-front-end/assets/2488775/7030d516-92cc-45f9-b548-ba1eeefdfc24)

#### A `title` attribute is included on the date column to reiterate the timing and length of the session.

Maybe overkill, but it’s hard to misinterpret!

<img width="877" alt="Screen Shot 2023-07-26 at 07 35 37 PM@2x" src="https://github.com/ddev/ddev.com-front-end/assets/2488775/c4d29063-b510-4fcc-8e45-cb2e601669ea">

#### A persistent callout on the “Support DDEV” page linking to this new one without being obnoxious.

<img width="700" alt="Screen Shot 2023-07-26 at 07 37 01 PM@2x" src="https://github.com/ddev/ddev.com-front-end/assets/2488775/da59ce1d-3b1e-4e01-b886-01ef012ef082">


#### Clicking “Register” next to an upcoming event prefills the “Session” input and scrolls to the form.

![Screen Shot 2023-07-26 at 07 38 00 PM@2x](https://github.com/ddev/ddev.com-front-end/assets/2488775/ef6aba61-f4a5-4e5c-b5e9-a3f26d74a821)

### The Form

I don’t know how this part is supposed to work, so I made up a quick + ideal flow:

1. Added a field for designating whatever session someone’s interested in, because otherwise how do you know which they should be invited to?
2. Consolidated “First Name” and “Last Name” into “Name” to speed things up. (Does it matter if you have someone’s first name only if you mainly need their email address?)
3. Removed “Company”, assuming that’s not pertinent to the contributor training signup.

It doesn’t do anything yet, and I didn’t bother copying all the cruft in from the Zoho CRM snippet.

Its narrower breakpoints are also lame at the moment, so yikes on mobile.