### PR TITLE
Minor time-has-passed updates to tutorials

### DIFF
--- a/src/components/AnimatedTerminal.astro
+++ b/src/components/AnimatedTerminal.astro
@@ -54,7 +54,8 @@ Container ddev-router  Running
       output: `ddev describe
 ┌─────────────────────────────────────────────────────────────────────────────────────┐
 │ Project: my-project ~/dev/my-project https://my-project.ddev.site                   │
-│ Docker environment: docker 20.10.21                                                 │
+│ Docker platform: docker-desktop                                                   │
+│ Router: traefik                                                 │
 ├────────────┬──────┬────────────────────────────────────────────┬────────────────────┤
 │ SERVICE    │ STAT │ URL/PORT                                   │ INFO               │
 ├────────────┼──────┼────────────────────────────────────────────┼────────────────────┤

--- a/src/components/quickstart/Mac.astro
+++ b/src/components/quickstart/Mac.astro
@@ -31,7 +31,7 @@ const { latestVersion } = Astro.props
         With <a href="https://brew.sh" target="_blank">Homebrew</a> installed, you
         can install Docker Desktop with one command:
       </p>
-      <Terminal code={`→ brew install homebrew/cask/docker`} />
+      <Terminal code={`→ brew install --cask docker`} />
     </div>
   </Fragment>
   <Fragment slot="Download">
@@ -53,7 +53,7 @@ const { latestVersion } = Astro.props
   </p>
 
   <p>Confirm that you’ve now got a Docker provider:</p>
-  <Terminal code={`→ docker -v\nDocker version 20.10.21, build baeda1f`} />
+  <Terminal code={`→ docker -v\nDocker version 24.0.5, build ced0996`} />
 
   <h2 class="text-3xl mt-24">
     <small class="block font-mono text-xs text-gray-500">2/3</small>Install DDEV

--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -39,7 +39,7 @@ const { latestVersion } = Astro.props
 
   <Terminal
     type="powershell"
-    code={`> wsl -l -v\n  NAME                   STATE           VERSION\n* Ubuntu-20.04           Stopped         2`}
+    code={`> wsl -l -v\n  NAME                   STATE           VERSION\n* Ubuntu                 Stopped         2`}
   />
 </div>
 


### PR DESCRIPTION
## The Issue

Some minor things getting out of date.

Reviewing this as a result of reading the [Nix docs](https://nix.dev/tutorials/#tutorials), which have tutorials to start with, like you have here. I'd sure like to figure out how to incorporate the amazing work you've done here directly into the docs. Or docs directly into ddev.com (better). 

It's so important for people to have an easy startup experience, and right now the docs are scattered, as hard as they try. ddev.com is much better.