### PR TITLE
Add image for ddev.com training

### DIFF
--- a/src/content/blog/contributor-training.md
+++ b/src/content/blog/contributor-training.md
@@ -1,7 +1,7 @@
 ---
 title: "DDEV Contributor Live Training"
 pubDate: 2023-07-09
-modifiedDate: 2023-07-23
+modifiedDate: 2023-08-23
 summary: Live contributor training is available for those who want to learn to contribute and maintain DDEV.
 author: Randy Fay
 #featureImage:

--- a/src/content/blog/ddev-website-for-contributors.md
+++ b/src/content/blog/ddev-website-for-contributors.md
@@ -1,14 +1,18 @@
 ---
 title: "DDEV Website for Contributors"
 pubDate: 2023-08-15
+modifiedDate: 2023-08-23
 summary: Matt Stein on maintaining and improving ddev.com.
 author: Matt Stein
+featureImage:
+  src: /img/blog/2023/08/cloudflare-deploying-pages.png
+  alt: Deploying to ddev.com
 categories:
   - Community
   - Guides
 ---
 
-The following is based on [Matt Stein's presentation outline](https://doc.mattstein.com/s/-BQQaSLJd) for the August 15, 2023 DDEV contributor training. Recordings of all past sessions can be found in the blog post [DDEV Contributor Live Training](/blog/contributor-training).
+The following is based on [Matt Stein's presentation outline](https://doc.mattstein.com/s/-BQQaSLJd) for the August 15, 2023 DDEV contributor training. Recordings of all past sessions can be found in the blog post [DDEV Contributor Live Training](/blog/contributor-training). This post was prepared (Thanks!) by [Kristin Wiseman](https://github.com/kristin-wiseman).
 
 ## Welcome!
 


### PR DESCRIPTION
## The Issue

* Add image that was intended to land earlier but wasn't referenced in https://github.com/ddev/ddev.com-front-end/pull/83
* Add credit for @kristin-wiseman in that one
* Update modified date on contributor training

I hope this is OK @kristin-wiseman 